### PR TITLE
Fix deisa bridge release not called

### DIFF
--- a/plugins/deisa/CHANGELOG.md
+++ b/plugins/deisa/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to the Deisa plugin will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 
+## [Unreleased]
+
+#### Fixed
+* Fixed a bug where the plugin would not call the bridge's release method.
+  [#534](https://github.com/pdidev/pdi/issues/534)
+
+
 ## [1.8.1] - 2025-01-23
 
 ### Fixed

--- a/plugins/deisa/deisa.cxx
+++ b/plugins/deisa/deisa.cxx
@@ -106,7 +106,7 @@ public:
 		}
 	}
 
-	~deisa_plugin() noexcept
+	~deisa_plugin() noexcept override
 	{
 		context().logger().info("Closing plugin");
 		try {

--- a/plugins/deisa/deisa.cxx
+++ b/plugins/deisa/deisa.cxx
@@ -51,6 +51,7 @@ class deisa_plugin: public Plugin
 	std::unordered_map<std::string, Datatype_template_sptr> m_deisa_arrays;
 	Expression m_time_step;
 	py::object m_bridge = py::none();
+	bool m_interpreter_initialized_in_plugin = false; // Determine if python interpreter is initialized by the plugin
 
 public:
 	static std::pair<std::unordered_set<std::string>, std::unordered_set<std::string>> dependencies() { return {{"mpi"}, {"mpi"}}; }
@@ -60,6 +61,7 @@ public:
 	{
 		if (!Py_IsInitialized()) {
 			py::initialize_interpreter();
+			m_interpreter_initialized_in_plugin = true;
 		}
 		assert(Py_IsInitialized());
 
@@ -113,6 +115,9 @@ public:
 			assert(hasattr(m_bridge, "release"));
 			m_bridge.attr("release")();
 			m_bridge = py::none();
+			if (m_interpreter_initialized_in_plugin) {
+				py::finalize_interpreter();
+			}
 		} catch (const std::exception& e) {
 			context().logger().error("Exception in destructor, caught exception {}", e.what());
 		} catch (...) {


### PR DESCRIPTION
This PR fixes a bug in deisa where the bridge's `release` method was never called.
Fixes #534 

# List of things to check before making a PR

Before merging your code, please check the following:

* [x] you have added a line describing your changes to the Changelog;
* [ ] you have added unit tests for any new or improved feature;
* [x] In case you updated dependencies, you have checked pdi/docs/CheckList.md
* you have checked your code format:
  - [x] you have checked that you respect all conventions specified in CONTRIBUTING.md;
  - [x] you have checked that the indentation and formatting conforms to the `.clang-format`;
  - [x] you have documented with doxygen any new or changed function / class;
* you have correctly updated the copyright headers:
  - [x] your institution is in the copyright header of every file you (substantially) modified;
  - [x] you have checked that the end-year of the copyright there is the current one;
* you have updated the AUTHORS file:
  - [x] you have added yourself to the AUTHORS file;
  - [x] if this is a new contribution, you have added it to the AUTHORS file;
* you have added everything to the user documentation:
  - [x] any new CMake configuration option;
  - [x] any change in the yaml config;
  - [x] any change to the public or plugin API;
  - [x] any other new or changed user-facing feature;
  - [x] any change to the dependencies;
* you have correctly linked your MR to one or more issues:
  - [x] your MR solves an identified issue;
  - [x] your commit contain the `Fix #issue` keyword to autoclose the issue when merged.
