### PR TITLE
MACOS compile with user_code plugin

### DIFF
--- a/plugins/user_code/CHANGELOG.md
+++ b/plugins/user_code/CHANGELOG.md
@@ -13,6 +13,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Deprecated
 
 ### Removed
+* remove header file `<link.h>`
 
 ### Fixed
 

--- a/plugins/user_code/CHANGELOG.md
+++ b/plugins/user_code/CHANGELOG.md
@@ -13,9 +13,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Deprecated
 
 ### Removed
-* remove header file `<link.h>`
 
 ### Fixed
+* Fix macOS compile issue with the user-code plugin [#539](https://github.com/pdidev/pdi/issues/539)
 
 ### Security
 

--- a/plugins/user_code/user_code.cxx
+++ b/plugins/user_code/user_code.cxx
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (C) 2015-2019 Commissariat a l'energie atomique et aux energies alternatives (CEA)
+ * Copyright (C) 2015-2025 Commissariat a l'energie atomique et aux energies alternatives (CEA)
  * Copyright (C) 2021 Institute of Bioorganic Chemistry Polish Academy of Science (PSNC)
  * All rights reserved.
  *

--- a/plugins/user_code/user_code.cxx
+++ b/plugins/user_code/user_code.cxx
@@ -29,7 +29,6 @@
 #include <vector>
 
 #include <dlfcn.h>
-#include <link.h>
 
 #include <pdi.h>
 #include <pdi/context.h>


### PR DESCRIPTION
When trying to compile the user-code plugin on macOS, the compiler could not find the header link.h

# List of things to check before making a PR

Before merging your code, please check the following:

* [x] you have added a line describing your changes to the Changelog;
* [x] you have added unit tests for any new or improved feature;
* [x] In case you updated dependencies, you have checked pdi/docs/CheckList.md
* you have checked your code format:
  - [x] you have checked that you respect all conventions specified in CONTRIBUTING.md;
  - [x] you have checked that the indentation and formatting conforms to the `.clang-format`;
  - [x] you have documented with doxygen any new or changed function / class;
* you have correctly updated the copyright headers:
  - [x] your institution is in the copyright header of every file you (substantially) modified;
  - [x] you have checked that the end-year of the copyright there is the current one;
* you have updated the AUTHORS file:
  - [x] you have added yourself to the AUTHORS file;
  - [x] if this is a new contribution, you have added it to the AUTHORS file;
* you have added everything to the user documentation:
  - [x] any new CMake configuration option;
  - [x] any change in the yaml config;
  - [x] any change to the public or plugin API;
  - [x] any other new or changed user-facing feature;
  - [x] any change to the dependencies;
* you have correctly linked your MR to one or more issues:
  - [x] your MR solves an identified issue;
  - [x] your commit contain the `Fix #issue` keyword to autoclose the issue when merged.
