### PR TITLE
Fix macos compile issues

### DIFF
--- a/pdi/CHANGELOG.md
+++ b/pdi/CHANGELOG.md
@@ -38,6 +38,8 @@ and this project adheres to
 #### Removed
 
 #### Fixed
+* Aligned memory allocation using `operator new`, fixes
+  [#550](https://github.com/pdidev/pdi/issues/550) 
 
 #### Security
 

--- a/pdi/CHANGELOG.md
+++ b/pdi/CHANGELOG.md
@@ -40,6 +40,7 @@ and this project adheres to
 #### Fixed
 * Aligned memory allocation using `operator new`, fixes
   [#550](https://github.com/pdidev/pdi/issues/550) 
+* Fix compile issue with macOS where `std::numeric_limits<uint64_t>::min()` is interpreted as `unsigned long long`
 
 #### Security
 

--- a/pdi/src/expression/impl.cxx
+++ b/pdi/src/expression/impl.cxx
@@ -119,7 +119,7 @@ Ref Expression::Impl::to_ref(Context& ctx, Datatype_sptr type) const
 
 	// option 4: use operator new with align_val_t (C++17)
 	auto data = operator new (type->buffersize(), static_cast<std::align_val_t>(type->alignment()));
-	Ref_rw result{data, [](void* v) { operator delete(v); }, type, true, true};
+	Ref_rw result{data, [](void* v) { operator delete (v); }, type, true, true};
 	copy_value(ctx, result.get(), type);
 	return result;
 }

--- a/pdi/src/expression/impl.cxx
+++ b/pdi/src/expression/impl.cxx
@@ -119,7 +119,7 @@ Ref Expression::Impl::to_ref(Context& ctx, Datatype_sptr type) const
 
 	// option 4: use aligned_alloc, falls back to use operator new with align_val_t (C++17)
 	auto data = std::aligned_alloc(type->alignment(), type->buffersize());
-	if(data) {
+	if (data) {
 		Ref_rw result{data, [](void* v) { free(v); }, type, true, true};
 		copy_value(ctx, result.get(), type);
 		return result;

--- a/pdi/src/expression/impl.cxx
+++ b/pdi/src/expression/impl.cxx
@@ -123,8 +123,7 @@ Ref Expression::Impl::to_ref(Context& ctx, Datatype_sptr type) const
 		Ref_rw result{data, [](void* v) { free(v); }, type, true, true};
 		copy_value(ctx, result.get(), type);
 		return result;
-	}
-	else {
+	} else {
 		auto al = static_cast<std::align_val_t>(type->alignment());
 		data = operator new (type->buffersize(), al);
 		Ref_rw result{data, [al](void* v) { operator delete (v, al); }, type, true, true};

--- a/pdi/src/expression/impl.cxx
+++ b/pdi/src/expression/impl.cxx
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (C) 2015-2021 Commissariat a l'energie atomique et aux energies alternatives (CEA)
+ * Copyright (C) 2015-2025 Commissariat a l'energie atomique et aux energies alternatives (CEA)
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/pdi/src/expression/impl.cxx
+++ b/pdi/src/expression/impl.cxx
@@ -87,12 +87,12 @@ Ref Expression::Impl::to_ref(Context& ctx, Datatype_sptr type) const
 	// return result;
 
 	// === option 1: use hand-written version fo aligned_alloc
-	size_t size = type->buffersize() + (type->alignment() - 1);
-	void* buffer = operator new (size);
-	void* data = std::align(type->alignment(), type->buffersize(), buffer, size);
-	Ref_rw result{data, [buffer](void*) { operator delete (buffer); }, type, true, true};
-	copy_value(ctx, result.get(), type);
-	return result;
+	// size_t size = type->buffersize() + (type->alignment() - 1);
+	// void* buffer = operator new (size);
+	// void* data = std::align(type->alignment(), type->buffersize(), buffer, size);
+	// Ref_rw result{data, [buffer](void*) { operator delete (buffer); }, type, true, true};
+	// copy_value(ctx, result.get(), type);
+	// return result;
 
 	// === option 2: use posix_memalign
 	// void * data;
@@ -116,6 +116,12 @@ Ref Expression::Impl::to_ref(Context& ctx, Datatype_sptr type) const
 	// 	copy_value(ctx, result.get(), type);
 	// 	return result;
 	// }
+
+	// option 4: use operator new with align_val_t (C++17)
+	auto data = operator new (type->buffersize(), static_cast<std::align_val_t>(type->alignment()));
+	Ref_rw result{data, [](void* v) { operator delete(v); }, type, true, true};
+	copy_value(ctx, result.get(), type);
+	return result;
 }
 
 unique_ptr<Expression::Impl> Expression::Impl::parse(PC_tree_t value)

--- a/pdi/src/expression/impl.cxx
+++ b/pdi/src/expression/impl.cxx
@@ -118,8 +118,9 @@ Ref Expression::Impl::to_ref(Context& ctx, Datatype_sptr type) const
 	// }
 
 	// option 4: use operator new with align_val_t (C++17)
-	auto data = operator new (type->buffersize(), static_cast<std::align_val_t>(type->alignment()));
-	Ref_rw result{data, [](void* v) { operator delete (v); }, type, true, true};
+	auto al = static_cast<std::align_val_t>(type->alignment());
+	auto data = operator new (type->buffersize(), al);
+	Ref_rw result{data, [al](void* v) { operator delete (v, al); }, type, true, true};
 	copy_value(ctx, result.get(), type);
 	return result;
 }

--- a/pdi/tests/CMakeLists.txt
+++ b/pdi/tests/CMakeLists.txt
@@ -105,6 +105,10 @@ endforeach()
 target_compile_features(PDI_unit_tests PRIVATE cxx_std_17)
 target_link_libraries(PDI_unit_tests PDI::PDI_plugins Threads::Threads GTest::gtest GTest::gtest_main GTest::gmock GTest::gmock_main)
 target_include_directories(PDI_unit_tests PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}/../src")
+set_target_properties(PDI_unit_tests PROPERTIES
+    INSTALL_RPATH "${CMAKE_BINARY_DIR}/staging/lib"
+)
+
 gtest_discover_tests(PDI_unit_tests)
 
 find_program(ZSH_PROGRAM zsh)

--- a/pdi/tests/CMakeLists.txt
+++ b/pdi/tests/CMakeLists.txt
@@ -1,5 +1,5 @@
 #=============================================================================
-# Copyright (C) 2015-2024 Commissariat a l'energie atomique et aux energies alternatives (CEA)
+# Copyright (C) 2015-2025 Commissariat a l'energie atomique et aux energies alternatives (CEA)
 # Copyright (C) 2018 Institute of Bioorganic Chemistry Polish Academy of Science (PSNC)
 # All rights reserved.
 #

--- a/pdi/tests/operators.h
+++ b/pdi/tests/operators.h
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (C) 2015-2022 Commissariat a l'energie atomique et aux energies alternatives (CEA)
+ * Copyright (C) 2015-2025 Commissariat a l'energie atomique et aux energies alternatives (CEA)
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/pdi/tests/operators.h
+++ b/pdi/tests/operators.h
@@ -180,10 +180,18 @@ inline constexpr auto ALL_VALS<int8_t>
        std::numeric_limits<int8_t>::max()};
 
 template <>
-inline constexpr auto ALL_VALS<uint64_t> = {std::numeric_limits<uint64_t>::min() + 1, -1ul, 1ul, std::numeric_limits<uint64_t>::max()};
+inline constexpr auto ALL_VALS<uint64_t>
+    = {static_cast<uint64_t>(std::numeric_limits<uint64_t>::min() + 1),
+	   static_cast<uint64_t>(-1),
+	   static_cast<uint64_t>(1),
+	   std::numeric_limits<uint64_t>::max()}; 
 
 template <>
-inline constexpr auto ALL_VALS< int64_t> = {std::numeric_limits<int64_t>::min() + 1, -1l, 1l, std::numeric_limits<int64_t>::max()};
+inline constexpr auto ALL_VALS<int64_t>
+    = {static_cast<int64_t>(std::numeric_limits<int64_t>::min() + 1),
+	   static_cast<int64_t>(-1),
+	   static_cast<int64_t>(1),
+	   std::numeric_limits<int64_t>::max()};
 
 template <>
 inline constexpr auto ALL_VALS<float> = {std::numeric_limits<float>::min(), -1.5f, -1.f, -.5f, .5f, 1.f, 1.5f, std::numeric_limits<float>::max()};

--- a/pdi/tests/operators.h
+++ b/pdi/tests/operators.h
@@ -181,17 +181,17 @@ inline constexpr auto ALL_VALS<int8_t>
 
 template <>
 inline constexpr auto ALL_VALS<uint64_t>
-    = {static_cast<uint64_t>(std::numeric_limits<uint64_t>::min() + 1),
-	   static_cast<uint64_t>(-1),
-	   static_cast<uint64_t>(1),
-	   std::numeric_limits<uint64_t>::max()}; 
+	= {static_cast<uint64_t>(std::numeric_limits<uint64_t>::min() + 1),
+       static_cast<uint64_t>(-1),
+       static_cast<uint64_t>(1),
+       std::numeric_limits<uint64_t>::max()};
 
 template <>
 inline constexpr auto ALL_VALS<int64_t>
-    = {static_cast<int64_t>(std::numeric_limits<int64_t>::min() + 1),
-	   static_cast<int64_t>(-1),
-	   static_cast<int64_t>(1),
-	   std::numeric_limits<int64_t>::max()};
+	= {static_cast<int64_t>(std::numeric_limits<int64_t>::min() + 1),
+       static_cast<int64_t>(-1),
+       static_cast<int64_t>(1),
+       std::numeric_limits<int64_t>::max()};
 
 template <>
 inline constexpr auto ALL_VALS<float> = {std::numeric_limits<float>::min(), -1.5f, -1.f, -.5f, .5f, 1.f, 1.5f, std::numeric_limits<float>::max()};

--- a/plugins/user_code/CHANGELOG.md
+++ b/plugins/user_code/CHANGELOG.md
@@ -13,6 +13,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Deprecated
 
 ### Removed
+* remove header file `<link.h>`
 
 ### Fixed
 

--- a/plugins/user_code/CHANGELOG.md
+++ b/plugins/user_code/CHANGELOG.md
@@ -13,9 +13,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Deprecated
 
 ### Removed
-* remove header file `<link.h>`
 
 ### Fixed
+* Fix macOS compile issue with the user-code plugin [#539](https://github.com/pdidev/pdi/issues/539)
 
 ### Security
 

--- a/plugins/user_code/user_code.cxx
+++ b/plugins/user_code/user_code.cxx
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (C) 2015-2019 Commissariat a l'energie atomique et aux energies alternatives (CEA)
+ * Copyright (C) 2015-2025 Commissariat a l'energie atomique et aux energies alternatives (CEA)
  * Copyright (C) 2021 Institute of Bioorganic Chemistry Polish Academy of Science (PSNC)
  * All rights reserved.
  *

--- a/plugins/user_code/user_code.cxx
+++ b/plugins/user_code/user_code.cxx
@@ -29,7 +29,6 @@
 #include <vector>
 
 #include <dlfcn.h>
-#include <link.h>
 
 #include <pdi.h>
 #include <pdi/context.h>


### PR DESCRIPTION
Try to fix macos compile issue with AppleClang
`std::numeric_limits<uint64_t>::min()` is interpreted as `unsigned long long`
`std::numeric_limits<int64_t>::min()` is interpreted as `long long`

# List of things to check before making a PR

Before merging your code, please check the following:

* [x] you have added a line describing your changes to the Changelog;
* [x] you have added unit tests for any new or improved feature;
* [x] In case you updated dependencies, you have checked pdi/docs/CheckList.md
* you have checked your code format:
  - [x] you have checked that you respect all conventions specified in CONTRIBUTING.md;
  - [x] you have checked that the indentation and formatting conforms to the `.clang-format`;
  - [x] you have documented with doxygen any new or changed function / class;
* you have correctly updated the copyright headers:
  - [x] your institution is in the copyright header of every file you (substantially) modified;
  - [x] you have checked that the end-year of the copyright there is the current one;
* you have updated the AUTHORS file:
  - [x] you have added yourself to the AUTHORS file;
  - [x] if this is a new contribution, you have added it to the AUTHORS file;
* you have added everything to the user documentation:
  - [x] any new CMake configuration option;
  - [x] any change in the yaml config;
  - [x] any change to the public or plugin API;
  - [x] any other new or changed user-facing feature;
  - [x] any change to the dependencies;
* you have correctly linked your MR to one or more issues:
  - [x] your MR solves an identified issue;
  - [x] your commit contain the `Fix #issue` keyword to autoclose the issue when merged.
