### PR TITLE
ignore attributes which are supported by some plugins

### DIFF
--- a/plugins/decl_hdf5/CHANGELOG.md
+++ b/plugins/decl_hdf5/CHANGELOG.md
@@ -11,6 +11,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   [#419](https://gitlab.maisondelasimulation.fr/pdidev/pdi/-/issues/419)
 
 ### Changed
+* Throw a waring instead of an error when a unknown key is parsed.
 
 ### Deprecated
 

--- a/plugins/decl_hdf5/file_op.cxx
+++ b/plugins/decl_hdf5/file_op.cxx
@@ -101,7 +101,9 @@ vector<File_op> File_op::parse(Context& ctx, PC_tree_t tree)
 			// will read in pass 2
 		} else if (key == "logging") {
 			// pass
-		} else {
+		} else if (key == "variables") {
+			// pass
+		}  else {
 			throw Config_error{key_tree, "Unknown key in HDF5 file configuration: `{}'", key};
 		}
 	});

--- a/plugins/decl_hdf5/file_op.cxx
+++ b/plugins/decl_hdf5/file_op.cxx
@@ -103,7 +103,7 @@ vector<File_op> File_op::parse(Context& ctx, PC_tree_t tree)
 			// pass
 		} else if (key == "variables") {
 			// pass
-		}  else {
+		} else {
 			throw Config_error{key_tree, "Unknown key in HDF5 file configuration: `{}'", key};
 		}
 	});

--- a/plugins/decl_hdf5/file_op.cxx
+++ b/plugins/decl_hdf5/file_op.cxx
@@ -101,10 +101,8 @@ vector<File_op> File_op::parse(Context& ctx, PC_tree_t tree)
 			// will read in pass 2
 		} else if (key == "logging") {
 			// pass
-		} else if (key == "variables") {
-			// pass
 		} else {
-			throw Config_error{key_tree, "Unknown key in HDF5 file configuration: `{}'", key};
+			ctx.logger().warn("Unknown key in HDF5 file configuration: `{}'", key);
 		}
 	});
 

--- a/plugins/decl_hdf5/file_op.cxx
+++ b/plugins/decl_hdf5/file_op.cxx
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (C) 2015-2024 Commissariat a l'energie atomique et aux energies alternatives (CEA)
+ * Copyright (C) 2015-2025 Commissariat a l'energie atomique et aux energies alternatives (CEA)
  * Copyright (C) 2021-2022 Institute of Bioorganic Chemistry Polish Academy of Science (PSNC)
  * All rights reserved.
  *


### PR DESCRIPTION
ignore `variables` attribute which is supported by `decl_netcdf` but not by `decl_hdf5`
In other words, we need to enforce the compatibility of yaml for both `decl_netcdf` and `decl_hdf5`

# List of things to check before making a PR

Before merging your code, please check the following:

* [x] you have added a line describing your changes to the Changelog;
* [x] you have added unit tests for any new or improved feature;
* [x] In case you updated dependencies, you have checked pdi/docs/CheckList.md
* you have checked your code format:
  - [x] you have checked that you respect all conventions specified in CONTRIBUTING.md;
  - [x] you have checked that the indentation and formatting conforms to the `.clang-format`;
  - [x] you have documented with doxygen any new or changed function / class;
* you have correctly updated the copyright headers:
  - [x] your institution is in the copyright header of every file you (substantially) modified;
  - [x] you have checked that the end-year of the copyright there is the current one;
* you have updated the AUTHORS file:
  - [x] you have added yourself to the AUTHORS file;
  - [x] if this is a new contribution, you have added it to the AUTHORS file;
* you have added everything to the user documentation:
  - [x] any new CMake configuration option;
  - [x] any change in the yaml config;
  - [x] any change to the public or plugin API;
  - [x] any other new or changed user-facing feature;
  - [x] any change to the dependencies;
* you have correctly linked your MR to one or more issues:
  - [x] your MR solves an identified issue;
  - [x] your commit contain the `Fix #issue` keyword to autoclose the issue when merged.
