### PR TITLE
Fix wrong function from abs to fabsf

### DIFF
--- a/plugins/set_value/tests/set_value_test_03_expose.c
+++ b/plugins/set_value/tests/set_value_test_03_expose.c
@@ -23,6 +23,7 @@
  ******************************************************************************/
 
 #include <assert.h>
+#include <math.h>
 
 #include <paraconf.h>
 #include <pdi.h>
@@ -167,13 +168,13 @@ int main(int argc, char* argv[])
 
 	//float
 	PDI_access("value_float", (void**)&value_float, PDI_IN);
-	assert(abs(*value_float - 4.14159265f) < 0.000001f);
+	assert(fabsf(*value_float - 4.14159265f) < 0.000001f);
 	PDI_release("value_float");
 
 	PDI_access("float_array", (void**)&float_array, PDI_IN);
-	assert(abs(float_array[0] - 2.23456789f) < 0.000001f);
-	assert(abs(float_array[1] - 13.3456789f) < 0.000001f);
-	assert(abs(float_array[2] - 124.456789f) < 0.000001f);
+	assert(fabsf(float_array[0] - 2.23456789f) < 0.000001f);
+	assert(fabsf(float_array[1] - 13.3456789f) < 0.000001f);
+	assert(fabsf(float_array[2] - 124.456789f) < 0.000001f);
 	PDI_release("float_array");
 
 	//double

--- a/plugins/set_value/tests/set_value_test_03_expose.c
+++ b/plugins/set_value/tests/set_value_test_03_expose.c
@@ -179,13 +179,13 @@ int main(int argc, char* argv[])
 
 	//double
 	PDI_access("value_double", (void**)&value_double, PDI_IN);
-	assert(*value_double == 4.14159265);
+	assert(fabs(*value_double - 4.14159265) < 0.000001);
 	PDI_release("value_double");
 
 	PDI_access("double_array", (void**)&double_array, PDI_IN);
-	assert(double_array[0] == 2.23456789);
-	assert(double_array[1] == 13.3456789);
-	assert(double_array[2] == 124.456789);
+	assert(fabs(double_array[0] - 2.23456789) < 0.000001);
+	assert(fabs(double_array[1] - 13.3456789) < 0.000001);
+	assert(fabs(double_array[2] - 124.456789) < 0.000001);
 	PDI_release("double_array");
 
 	PDI_access("string", (void**)&string, PDI_IN);

--- a/plugins/set_value/tests/set_value_test_03_share_set.c
+++ b/plugins/set_value/tests/set_value_test_03_share_set.c
@@ -23,6 +23,7 @@
  ******************************************************************************/
 
 #include <assert.h>
+#include <math.h>
 
 #include <paraconf.h>
 #include <pdi.h>
@@ -166,13 +167,13 @@ int main(int argc, char* argv[])
 
 	//float
 	PDI_access("value_float", (void**)&value_float, PDI_IN);
-	assert(abs(*value_float - 4.14159265f) < 0.000001f);
+	assert(fabsf(*value_float - 4.14159265f) < 0.000001f);
 	PDI_release("value_float");
 
 	PDI_access("float_array", (void**)&float_array, PDI_IN);
-	assert(abs(float_array[0] - 2.23456789f) < 0.000001f);
-	assert(abs(float_array[1] - 13.3456789f) < 0.000001f);
-	assert(abs(float_array[2] - 124.456789f) < 0.000001f);
+	assert(fabsf(float_array[0] - 2.23456789f) < 0.000001f);
+	assert(fabsf(float_array[1] - 13.3456789f) < 0.000001f);
+	assert(fabsf(float_array[2] - 124.456789f) < 0.000001f);
 	PDI_release("float_array");
 
 	//double

--- a/plugins/set_value/tests/set_value_test_03_share_set.c
+++ b/plugins/set_value/tests/set_value_test_03_share_set.c
@@ -178,13 +178,13 @@ int main(int argc, char* argv[])
 
 	//double
 	PDI_access("value_double", (void**)&value_double, PDI_IN);
-	assert(*value_double == 4.14159265);
+	assert(fabs(*value_double - 4.14159265) < 0.000001);
 	PDI_release("value_double");
 
 	PDI_access("double_array", (void**)&double_array, PDI_IN);
-	assert(double_array[0] == 2.23456789);
-	assert(double_array[1] == 13.3456789);
-	assert(double_array[2] == 124.456789);
+	assert(fabs(double_array[0] - 2.23456789) < 0.000001);
+	assert(fabs(double_array[1] - 13.3456789) < 0.000001);
+	assert(fabs(double_array[2] - 124.456789) < 0.000001);
 	PDI_release("double_array");
 
 	PDI_access("string", (void**)&string, PDI_IN);


### PR DESCRIPTION
In C, `abs` is only for integers, I think you should be using `fabs` instead.

# List of things to check before making a PR

Before merging your code, please check the following:

* [ ] you have added a line describing your changes to the Changelog;
* [ ] you have added unit tests for any new or improved feature;
* [ ] In case you updated dependencies, you have checked pdi/docs/CheckList.md
* you have checked your code format:
  - [ ] you have checked that you respect all conventions specified in CONTRIBUTING.md;
  - [ ] you have checked that the indentation and formatting conforms to the `.clang-format`;
  - [ ] you have documented with doxygen any new or changed function / class;
* you have correctly updated the copyright headers:
  - [ ] your institution is in the copyright header of every file you (substantially) modified;
  - [ ] you have checked that the end-year of the copyright there is the current one;
* you have updated the AUTHORS file:
  - [ ] you have added yourself to the AUTHORS file;
  - [ ] if this is a new contribution, you have added it to the AUTHORS file;
* you have added everything to the user documentation:
  - [ ] any new CMake configuration option;
  - [ ] any change in the yaml config;
  - [ ] any change to the public or plugin API;
  - [ ] any other new or changed user-facing feature;
  - [ ] any change to the dependencies;
* you have correctly linked your MR to one or more issues:
  - [ ] your MR solves an identified issue;
  - [ ] your commit contain the `Fix #issue` keyword to autoclose the issue when merged.
