### PR TITLE
553 expose const data

### DIFF
--- a/pdi/AUTHORS
+++ b/pdi/AUTHORS
@@ -12,6 +12,7 @@ Mohamed Gaalich - CEA (mohamed.gaalich@cea.fr)
 
 Benoit Martin - CEA (bmartin@cea.fr)
 * Add Context::find()
+* Add support for const data in `PDI_share`, `PDI_expose` and `PDI_multi_expose`
 
 Jacques Morice - CEA (jacques.morice@cea.fr)
 * Add Add operator== in Context::Iterator()

--- a/pdi/CHANGELOG.md
+++ b/pdi/CHANGELOG.md
@@ -15,6 +15,8 @@ and this project adheres to
 ### For users
 
 #### Added
+* `PDI_share`, `PDI_expose` and `PDI_multi_expose` now accept `const` data
+  [#553](https://github.com/pdidev/pdi/issues/553)
 
 #### Changed
 

--- a/pdi/include/pdi.h
+++ b/pdi/include/pdi.h
@@ -260,6 +260,13 @@ PDI_status_t PDI_EXPORT PDI_event(const char* event);
  */
 PDI_status_t PDI_EXPORT PDI_expose(const char* name, void* data, PDI_inout_t access);
 
+/** Shortly exposes some const data to PDI. Equivalent to PDI_share_const + PDI_reclaim.
+ * \param[in] name the data name
+ * \param[in] data the exposed data
+ * \return an error status
+ */
+PDI_status_t PDI_EXPORT PDI_expose_const(const char* name, const void* data);
+
 /** Performs multiple exposes at once. All the data is shared in order they were specified
  *  and reclaimed in reversed order after an event is triggered.
  *

--- a/pdi/include/pdi.h
+++ b/pdi/include/pdi.h
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright (C) 2015-2021 Commissariat a l'energie atomique et aux energies alternatives (CEA)
+* Copyright (C) 2015-2025 Commissariat a l'energie atomique et aux energies alternatives (CEA)
 * All rights reserved.
 *
 * Redistribution and use in source and binary forms, with or without

--- a/pdi/include/pdi.h
+++ b/pdi/include/pdi.h
@@ -282,7 +282,7 @@ PDI_status_t PDI_EXPORT PDI_expose_const(const char* name, const void* data);
  *                inidactes an end of the list.
  * \return an error status
  */
-PDI_status_t PDI_EXPORT PDI_multi_expose(const char* event_name, const char* name, void* data, PDI_inout_t access, ...);
+PDI_status_t PDI_EXPORT PDI_multi_expose(const char* event_name, const char* name, const void* data, PDI_inout_t access, ...);
 
 #ifdef PDI_WITH_DEPRECATED
 

--- a/pdi/include/pdi.h
+++ b/pdi/include/pdi.h
@@ -206,6 +206,17 @@ typedef enum PDI_inout_e {
  */
 PDI_status_t PDI_EXPORT PDI_share(const char* name, void* data, PDI_inout_t access);
 
+/** Shares some const data with PDI. The user code should not modify it before
+ * a call to either PDI_release or PDI_reclaim.
+ * \param[in] name the data name
+ * \param[in,out] data the accessed data
+
+ * \return an error status
+ * \pre the user code owns the data buffer
+ * \post ownership of the data buffer is shared between PDI and the user code
+ */
+PDI_status_t PDI_EXPORT PDI_share_const(const char* name, const void* data);
+
 /** Requests for PDI to access a data buffer.
  * \param[in] name the data name
  * \param[in,out] buffer a pointer to the accessed data buffer

--- a/pdi/include/pdi.h
+++ b/pdi/include/pdi.h
@@ -204,18 +204,7 @@ typedef enum PDI_inout_e {
  * * PDI_IN means PDI can set the buffer content
  * * PDI_OUT means the buffer contains data that can be accessed by PDI
  */
-PDI_status_t PDI_EXPORT PDI_share(const char* name, void* data, PDI_inout_t access);
-
-/** Shares some const data with PDI. The user code should not modify it before
- * a call to either PDI_release or PDI_reclaim.
- * \param[in] name the data name
- * \param[in,out] data the accessed data
-
- * \return an error status
- * \pre the user code owns the data buffer
- * \post ownership of the data buffer is shared between PDI and the user code
- */
-PDI_status_t PDI_EXPORT PDI_share_const(const char* name, const void* data);
+PDI_status_t PDI_EXPORT PDI_share(const char* name, const void* data, PDI_inout_t access);
 
 /** Requests for PDI to access a data buffer.
  * \param[in] name the data name
@@ -258,14 +247,7 @@ PDI_status_t PDI_EXPORT PDI_event(const char* event);
  *                   by PDI
  * \return an error status
  */
-PDI_status_t PDI_EXPORT PDI_expose(const char* name, void* data, PDI_inout_t access);
-
-/** Shortly exposes some const data to PDI. Equivalent to PDI_share_const + PDI_reclaim.
- * \param[in] name the data name
- * \param[in] data the exposed data
- * \return an error status
- */
-PDI_status_t PDI_EXPORT PDI_expose_const(const char* name, const void* data);
+PDI_status_t PDI_EXPORT PDI_expose(const char* name, const void* data, PDI_inout_t access);
 
 /** Performs multiple exposes at once. All the data is shared in order they were specified
  *  and reclaimed in reversed order after an event is triggered.

--- a/pdi/src/pdi.cxx
+++ b/pdi/src/pdi.cxx
@@ -145,10 +145,10 @@ void warn_status(PDI_status_t status, const char* message, void*)
 
 } // namespace
 
-
 namespace PDI {
 
-PDI_status_t share(const char* name, void* buffer, PDI_inout_t access) {
+PDI_status_t share(const char* name, void* buffer, PDI_inout_t access)
+{
 	try {
 		Paraconf_wrapper fw;
 		Global_context::context()[name].share(buffer, access & PDI_OUT, access & PDI_IN);
@@ -162,12 +162,14 @@ PDI_status_t share(const char* name, void* buffer, PDI_inout_t access) {
 	}
 }
 
-PDI_status_t share(const char* name, const void* buffer, PDI_inout_t access) {
+PDI_status_t share(const char* name, const void* buffer, PDI_inout_t access)
+{
 	return share(name, const_cast<void*>(buffer), access);
 }
 
-template<typename T>
-PDI_status_t expose(const char* name, T data, PDI_inout_t access) {
+template <typename T>
+PDI_status_t expose(const char* name, T data, PDI_inout_t access)
+{
 	try {
 		Paraconf_wrapper fw;
 		if (PDI_status_t status = PDI::share(name, data, access)) {
@@ -197,7 +199,6 @@ PDI_status_t expose(const char* name, T data, PDI_inout_t access) {
 }
 
 } // namespace PDI
-
 
 extern "C" {
 
@@ -293,11 +294,13 @@ try {
 	return g_error_context.return_err();
 }
 
-PDI_status_t PDI_share(const char* name, void* buffer, PDI_inout_t access) {
+PDI_status_t PDI_share(const char* name, void* buffer, PDI_inout_t access)
+{
 	return PDI::share(name, buffer, access);
 }
 
-PDI_status_t PDI_share_const(const char* name, const void* buffer) {
+PDI_status_t PDI_share_const(const char* name, const void* buffer)
+{
 	return PDI::share(name, buffer, PDI_OUT);
 }
 
@@ -341,11 +344,13 @@ try {
 	return g_error_context.return_err();
 }
 
-PDI_status_t PDI_expose(const char* name, void* data, PDI_inout_t access) {
+PDI_status_t PDI_expose(const char* name, void* data, PDI_inout_t access)
+{
 	return PDI::expose(name, data, access);
 }
 
-PDI_status_t PDI_expose_const(const char* name, const void* data) {
+PDI_status_t PDI_expose_const(const char* name, const void* data)
+{
 	return PDI::expose(name, data, PDI_OUT);
 }
 

--- a/pdi/src/pdi.cxx
+++ b/pdi/src/pdi.cxx
@@ -252,6 +252,18 @@ try {
 	return g_error_context.return_err();
 }
 
+PDI_status_t PDI_share_const(const char* name, const void* buffer)
+try {
+	PDI_share(name, const_cast<void*>(buffer), PDI_OUT);
+	return PDI_OK;
+} catch (const Error& e) {
+	return g_error_context.return_err(e);
+} catch (const exception& e) {
+	return g_error_context.return_err(e);
+} catch (...) {
+	return g_error_context.return_err();
+}
+
 PDI_status_t PDI_access(const char* name, void** buffer, PDI_inout_t inout)
 try {
 	Paraconf_wrapper fw;

--- a/pdi/src/pdi.cxx
+++ b/pdi/src/pdi.cxx
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (C) 2015-2021 Commissariat a l'energie atomique et aux energies alternatives (CEA)
+ * Copyright (C) 2015-2025 Commissariat a l'energie atomique et aux energies alternatives (CEA)
  * Copyright (C) 2021 Institute of Bioorganic Chemistry Polish Academy of Science (PSNC)
  * All rights reserved.
  *

--- a/pdi/src/pdi.cxx
+++ b/pdi/src/pdi.cxx
@@ -360,7 +360,7 @@ try {
 	return status;
 }
 
-PDI_status_t PDI_multi_expose(const char* event_name, const char* name, void* data, PDI_inout_t access, ...)
+PDI_status_t PDI_multi_expose(const char* event_name, const char* name, const void* data, PDI_inout_t access, ...)
 try {
 	Paraconf_wrapper fw;
 	va_list ap;

--- a/pdi/src/pdi.cxx
+++ b/pdi/src/pdi.cxx
@@ -162,9 +162,9 @@ try {
 
 template<>
 PDI_status_t PDI_share(const char* name, const void* buffer, PDI_inout_t access) {
-	// if(PDI_OUT != access) {
-	// 	throw Right_error("Sharing a const buffer can only be done using PDI_IN access rights.");
-	// }
+	if(PDI_OUT != access) {
+		throw Right_error("Sharing a const buffer can only be done using PDI_IN access rights.");
+	}
 	return PDI_share(name, const_cast<void*>(buffer), access);
 }
 

--- a/pdi/tests/PDI_C_API.cxx
+++ b/pdi/tests/PDI_C_API.cxx
@@ -102,3 +102,36 @@ TEST_F(PdiCApiTest, MetadataDensification)
 		EXPECT_EQ(dense_array[i], (i / 20 + 1) * 100 + (i / 5 % 4 + 2) * 10 + i % 5 + 3);
 	}
 }
+
+/* Name:                PdiCApiTest.PDI_expose
+ *
+ * Tested functions:    PDI_share(), PDI_share_const()
+ *
+ * Description:         Test PDI_share API call
+ */
+TEST_F(PdiCApiTest, PDI_share)
+{
+	static const char* CONFIG_YAML
+		= "logging: trace         \n"
+		  "metadata:              \n"
+		  "  my_int: int \n";
+		  "  my_const_int: int \n";
+
+	PDI_init(PC_parse_string(CONFIG_YAML));
+
+	int i=42;
+	const int j=51;
+	int* int_ptr;
+
+	// share
+	PDI_share("my_int", &i, PDI_OUT);
+	EXPECT_EQ(i, 42);
+	PDI_access("my_int", (void**)&int_ptr, PDI_IN);
+	EXPECT_EQ(*int_ptr, 42);
+
+	// share_const
+	PDI_share_const("my_const_int", &j);	// no need for access as it is const data
+	EXPECT_EQ(j, 51);
+	PDI_access("my_const_int", (void**)&int_ptr, PDI_IN);
+	EXPECT_EQ(*int_ptr, 51);
+}

--- a/pdi/tests/PDI_C_API.cxx
+++ b/pdi/tests/PDI_C_API.cxx
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (C) 2015-2022 Commissariat a l'energie atomique et aux energies alternatives (CEA)
+ * Copyright (C) 2015-2025 Commissariat a l'energie atomique et aux energies alternatives (CEA)
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/pdi/tests/PDI_C_API.cxx
+++ b/pdi/tests/PDI_C_API.cxx
@@ -103,9 +103,10 @@ TEST_F(PdiCApiTest, MetadataDensification)
 	}
 }
 
-void test_share(PDI_inout_t access) {
-	int i=42;
-	const int j=51;
+void test_share(PDI_inout_t access)
+{
+	int i = 42;
+	const int j = 51;
 	int* int_ptr;
 
 	// share int
@@ -133,7 +134,8 @@ void test_share(PDI_inout_t access) {
  *
  * Description:         Test the share() API call with non-const and const data
  */
-TEST_F(PdiCApiTest, PDI_share) {
+TEST_F(PdiCApiTest, PDI_share)
+{
 	static const char* CONFIG_YAML = "logging: trace\n";
 	PDI_init(PC_parse_string(CONFIG_YAML));
 
@@ -141,10 +143,10 @@ TEST_F(PdiCApiTest, PDI_share) {
 	test_share(PDI_INOUT);
 }
 
-
-void test_expose(PDI_inout_t access) {
-	int i=42;
-	const int j=51;
+void test_expose(PDI_inout_t access)
+{
+	int i = 42;
+	const int j = 51;
 	int* int_ptr;
 
 	// expose int
@@ -164,7 +166,8 @@ void test_expose(PDI_inout_t access) {
  *
  * Description:         Test the expose() API call with non-const and const data
  */
-TEST_F(PdiCApiTest, PDI_expose) {
+TEST_F(PdiCApiTest, PDI_expose)
+{
 	static const char* CONFIG_YAML = "logging: trace\n";
 	PDI_init(PC_parse_string(CONFIG_YAML));
 
@@ -172,16 +175,14 @@ TEST_F(PdiCApiTest, PDI_expose) {
 	test_expose(PDI_INOUT);
 }
 
-void test_multi_expose(PDI_inout_t access) {
-	int i=42;
-	const int j=51;
+void test_multi_expose(PDI_inout_t access)
+{
+	int i = 42;
+	const int j = 51;
 	int* int_ptr;
 
 	// multi_expose int first
-	EXPECT_EQ(PDI_multi_expose("event",
-		"my_int1", &i, access,
-		"my_int2", &j, access,
-		NULL), PDI_OK);
+	EXPECT_EQ(PDI_multi_expose("event", "my_int1", &i, access, "my_int2", &j, access, NULL), PDI_OK);
 
 	// PDI_access("my_int1", (void**)&int_ptr, PDI_IN);
 	// EXPECT_EQ(*int_ptr, 51);
@@ -189,10 +190,7 @@ void test_multi_expose(PDI_inout_t access) {
 	// EXPECT_EQ(*int_ptr, 46);
 
 	// multi_expose const int first
-	EXPECT_EQ(PDI_multi_expose("event",
-		"my_int1", &j, access,
-		"my_int2", &i, access,
-		NULL), PDI_OK);
+	EXPECT_EQ(PDI_multi_expose("event", "my_int1", &j, access, "my_int2", &i, access, NULL), PDI_OK);
 
 	// PDI_access("my_int1", (void**)&int_ptr, PDI_IN);
 	// EXPECT_EQ(*int_ptr, 51);
@@ -206,7 +204,8 @@ void test_multi_expose(PDI_inout_t access) {
  *
  * Description:         Test the multi_expose() API call with non-const and const data
  */
-TEST_F(PdiCApiTest, PDI_multi_expose) {
+TEST_F(PdiCApiTest, PDI_multi_expose)
+{
 	static const char* CONFIG_YAML = "logging: trace\n";
 	PDI_init(PC_parse_string(CONFIG_YAML));
 

--- a/pdi/tests/PDI_C_API.cxx
+++ b/pdi/tests/PDI_C_API.cxx
@@ -115,14 +115,8 @@ void test_share(PDI_inout_t access)
 	EXPECT_EQ(PDI_access("my_int1", (void**)&int_ptr, PDI_IN), PDI_OK);
 	EXPECT_EQ(*int_ptr, 42);
 
-	// share_const with int
-	EXPECT_EQ(PDI_share_const("my_int1", &i), PDI_OK);
-	EXPECT_EQ(i, 42);
-	EXPECT_EQ(PDI_access("my_int1", (void**)&int_ptr, PDI_IN), PDI_OK);
-	EXPECT_EQ(*int_ptr, 42);
-
-	// share_const with const int
-	EXPECT_EQ(PDI_share_const("my_int1", &j), PDI_OK);
+	// share with const int
+	EXPECT_EQ(PDI_share("my_int1", &j, access), PDI_OK);
 	EXPECT_EQ(j, 51);
 	EXPECT_EQ(PDI_access("my_int1", (void**)&int_ptr, PDI_IN), PDI_OK);
 	EXPECT_EQ(*int_ptr, 51);
@@ -143,23 +137,6 @@ TEST_F(PdiCApiTest, PDI_share)
 	test_share(PDI_INOUT);
 }
 
-void test_expose(PDI_inout_t access)
-{
-	int i = 42;
-	const int j = 51;
-	int* int_ptr;
-
-	// expose int
-	EXPECT_EQ(PDI_expose("my_int1", &i, access), PDI_OK);
-	EXPECT_EQ(i, 42);
-	// EXPECT_EQ(PDI_access("my_int1", (void**)&int_ptr, PDI_IN), PDI_UNAVAILABLE);
-
-	// expose const int
-	EXPECT_EQ(PDI_expose_const("my_int1", &j), PDI_OK);
-	EXPECT_EQ(j, 51);
-	// EXPECT_EQ(PDI_access("my_int1", (void**)&int_ptr, PDI_IN), PDI_UNAVAILABLE);
-}
-
 /* Name:                PdiCApiTest.PDI_expose
  *
  * Tested functions:    PDI_expose(), PDI_expose_const()
@@ -171,31 +148,15 @@ TEST_F(PdiCApiTest, PDI_expose)
 	static const char* CONFIG_YAML = "logging: trace\n";
 	PDI_init(PC_parse_string(CONFIG_YAML));
 
-	test_expose(PDI_OUT);
-	test_expose(PDI_INOUT);
-}
-
-void test_multi_expose(PDI_inout_t access)
-{
 	int i = 42;
 	const int j = 51;
-	int* int_ptr;
 
-	// multi_expose int first
-	EXPECT_EQ(PDI_multi_expose("event", "my_int1", &i, access, "my_int2", &j, access, NULL), PDI_OK);
-
-	// PDI_access("my_int1", (void**)&int_ptr, PDI_IN);
-	// EXPECT_EQ(*int_ptr, 51);
-	// PDI_access("my_int2", (void**)&int_ptr, PDI_IN);
-	// EXPECT_EQ(*int_ptr, 46);
-
-	// multi_expose const int first
-	EXPECT_EQ(PDI_multi_expose("event", "my_int1", &j, access, "my_int2", &i, access, NULL), PDI_OK);
-
-	// PDI_access("my_int1", (void**)&int_ptr, PDI_IN);
-	// EXPECT_EQ(*int_ptr, 51);
-	// PDI_access("my_int2", (void**)&int_ptr, PDI_IN);
-	// EXPECT_EQ(*int_ptr, 47);
+	// expose int
+	EXPECT_EQ(PDI_expose("my_int1", &i, PDI_OUT), PDI_OK);
+	EXPECT_EQ(i, 42);
+	// expose const int
+	EXPECT_EQ(PDI_expose("my_int1", &j, PDI_OUT), PDI_OK);
+	EXPECT_EQ(j, 51);
 }
 
 /* Name:                PdiCApiTest.PDI_multi_expose
@@ -209,6 +170,24 @@ TEST_F(PdiCApiTest, PDI_multi_expose)
 	static const char* CONFIG_YAML = "logging: trace\n";
 	PDI_init(PC_parse_string(CONFIG_YAML));
 
-	test_multi_expose(PDI_OUT);
-	test_multi_expose(PDI_INOUT);
+	int i = 42;
+	const int j = 51;
+
+	// multi_expose int first
+	EXPECT_EQ(PDI_multi_expose("event", "my_int1", &i, PDI_OUT, "my_int2", &j, PDI_OUT, NULL), PDI_OK);
+	EXPECT_EQ(i, 42);
+	EXPECT_EQ(j, 51);
+	// multi_expose const int first
+	EXPECT_EQ(PDI_multi_expose("event", "my_int1", &j, PDI_OUT, "my_int2", &i, PDI_OUT, NULL), PDI_OK);
+	EXPECT_EQ(i, 42);
+	EXPECT_EQ(j, 51);
+
+	// multi_expose int first
+	EXPECT_EQ(PDI_multi_expose("event", "my_int1", &i, PDI_INOUT, "my_int2", &j, PDI_INOUT, NULL), PDI_OK);
+	EXPECT_EQ(i, 42);
+	EXPECT_EQ(j, 51);
+	// multi_expose const int first
+	EXPECT_EQ(PDI_multi_expose("event", "my_int1", &j, PDI_INOUT, "my_int2", &i, PDI_INOUT, NULL), PDI_OK);
+	EXPECT_EQ(i, 42);
+	EXPECT_EQ(j, 51);
 }

--- a/pdi/tests/PDI_C_API.cxx
+++ b/pdi/tests/PDI_C_API.cxx
@@ -103,13 +103,13 @@ TEST_F(PdiCApiTest, MetadataDensification)
 	}
 }
 
-/* Name:                PdiCApiTest.PDI_expose
+/* Name:                PdiCApiTest.PDI_share_expose
  *
  * Tested functions:    PDI_share(), PDI_share_const()
  *
  * Description:         Test PDI_share API call
  */
-TEST_F(PdiCApiTest, PDI_share)
+TEST_F(PdiCApiTest, PDI_share_expose)
 {
 	static const char* CONFIG_YAML
 		= "logging: trace         \n"
@@ -131,6 +131,18 @@ TEST_F(PdiCApiTest, PDI_share)
 
 	// share_const
 	PDI_share_const("my_const_int", &j);	// no need for access as it is const data
+	EXPECT_EQ(j, 51);
+	PDI_access("my_const_int", (void**)&int_ptr, PDI_IN);
+	EXPECT_EQ(*int_ptr, 51);
+
+	// expose
+	PDI_expose("my_int", &i, PDI_OUT);
+	EXPECT_EQ(i, 42);
+	PDI_access("my_int", (void**)&int_ptr, PDI_IN);
+	EXPECT_EQ(*int_ptr, 42);
+
+	// expose_const
+	PDI_expose_const("my_const_int", &j);	// no need for access as it is const data
 	EXPECT_EQ(j, 51);
 	PDI_access("my_const_int", (void**)&int_ptr, PDI_IN);
 	EXPECT_EQ(*int_ptr, 51);

--- a/pdi/tests/PDI_C_API.cxx
+++ b/pdi/tests/PDI_C_API.cxx
@@ -103,47 +103,86 @@ TEST_F(PdiCApiTest, MetadataDensification)
 	}
 }
 
-/* Name:                PdiCApiTest.PDI_share_expose
+/* Name:                PdiCApiTest.PDI_share_expose_multi_expose
  *
- * Tested functions:    PDI_share(), PDI_share_const()
+ * Tested functions:    PDI_share(), PDI_share_const(), PDI_multi_expose(), PDI_access()
  *
  * Description:         Test PDI_share API call
  */
-TEST_F(PdiCApiTest, PDI_share_expose)
+TEST_F(PdiCApiTest, PDI_share_expose_multi_expose)
 {
 	static const char* CONFIG_YAML
 		= "logging: trace         \n"
 		  "metadata:              \n"
-		  "  my_int: int \n";
-		  "  my_const_int: int \n";
+		  "  my_int1: int \n";
+		  "  my_int2: int \n";
 
 	PDI_init(PC_parse_string(CONFIG_YAML));
 
-	int i=42;
+	int i=0;
 	const int j=51;
 	int* int_ptr;
 
 	// share
-	PDI_share("my_int", &i, PDI_OUT);
+	i=42;
+	PDI_share("my_int1", &i, PDI_OUT);
 	EXPECT_EQ(i, 42);
-	PDI_access("my_int", (void**)&int_ptr, PDI_IN);
+	PDI_access("my_int1", (void**)&int_ptr, PDI_IN);
 	EXPECT_EQ(*int_ptr, 42);
 
-	// share_const
-	PDI_share_const("my_const_int", &j);	// no need for access as it is const data
+	// share_const with int
+	i=43;
+	PDI_share_const("my_int1", &i);
+	EXPECT_EQ(i, 43);
+	PDI_access("my_int1", (void**)&int_ptr, PDI_IN);
+	EXPECT_EQ(*int_ptr, 43);
+
+	// share_const with const int
+	PDI_share_const("my_int1", &j);
 	EXPECT_EQ(j, 51);
-	PDI_access("my_const_int", (void**)&int_ptr, PDI_IN);
+	PDI_access("my_int1", (void**)&int_ptr, PDI_IN);
 	EXPECT_EQ(*int_ptr, 51);
 
 	// expose
-	PDI_expose("my_int", &i, PDI_OUT);
-	EXPECT_EQ(i, 42);
-	PDI_access("my_int", (void**)&int_ptr, PDI_IN);
-	EXPECT_EQ(*int_ptr, 42);
-
-	// expose_const
-	PDI_expose_const("my_const_int", &j);	// no need for access as it is const data
-	EXPECT_EQ(j, 51);
-	PDI_access("my_const_int", (void**)&int_ptr, PDI_IN);
+	i=44;
+	PDI_expose("my_int1", &i, PDI_OUT);
+	EXPECT_EQ(i, 44);
+	PDI_access("my_int1", (void**)&int_ptr, PDI_IN);
 	EXPECT_EQ(*int_ptr, 51);
+
+	// expose_const with int
+	i=45;
+	PDI_expose_const("my_int1", &i);
+	EXPECT_EQ(i, 45);
+	PDI_access("my_int1", (void**)&int_ptr, PDI_IN);
+	EXPECT_EQ(*int_ptr, 51);
+
+	// expose_const with const int
+	PDI_expose_const("my_int1", &j);
+	EXPECT_EQ(j, 51);
+	PDI_access("my_int1", (void**)&int_ptr, PDI_IN);
+	EXPECT_EQ(*int_ptr, 51);
+
+	// multi_expose i first
+	i=46;
+	PDI_multi_expose("event",
+		"my_int1", &i, PDI_OUT,
+		"my_int2", &j, PDI_OUT,
+		NULL);
+	// PDI_access("my_int1", (void**)&int_ptr, PDI_IN);
+	// EXPECT_EQ(*int_ptr, 51);
+	// PDI_access("my_int2", (void**)&int_ptr, PDI_IN);
+	// EXPECT_EQ(*int_ptr, 51);
+
+
+	// multi_expose j first
+	i=47;
+	PDI_multi_expose("event",
+		"my_int1", &j, PDI_OUT,
+		"my_int2", &i, PDI_OUT,
+		NULL);
+	// PDI_access("my_int1", (void**)&int_ptr, PDI_IN);
+	// EXPECT_EQ(*int_ptr, 51);
+	// PDI_access("my_int2", (void**)&int_ptr, PDI_IN);
+	// EXPECT_EQ(*int_ptr, 51);
 }

--- a/pdi/tests/PDI_C_API.cxx
+++ b/pdi/tests/PDI_C_API.cxx
@@ -185,4 +185,13 @@ TEST_F(PdiCApiTest, PDI_share_expose_multi_expose)
 	// EXPECT_EQ(*int_ptr, 51);
 	// PDI_access("my_int2", (void**)&int_ptr, PDI_IN);
 	// EXPECT_EQ(*int_ptr, 51);
+
+	// right error
+	PDI_errhandler(PDI_NULL_HANDLER);
+	i=48;
+	PDI_status_t err = PDI_multi_expose("event",
+		"my_int1", &i, PDI_INOUT,	// ok
+		"my_int2", &j, PDI_INOUT,	// error
+		NULL);
+	EXPECT_EQ(err, PDI_ERR_RIGHT);
 }


### PR DESCRIPTION
`PDI_share`, `PDI_expose` and `PDI_multi_expose` now take a `const void*` for `data`.

Fixes #553 

# List of things to check before making a PR

Before merging your code, please check the following:

* [x] you have added a line describing your changes to the Changelog;
* [x] you have added unit tests for any new or improved feature;
* [x] In case you updated dependencies, you have checked pdi/docs/CheckList.md
* you have checked your code format:
  - [x] you have checked that you respect all conventions specified in CONTRIBUTING.md;
  - [x] you have checked that the indentation and formatting conforms to the `.clang-format`;
  - [x] you have documented with doxygen any new or changed function / class;
* you have correctly updated the copyright headers:
  - [x] your institution is in the copyright header of every file you (substantially) modified;
  - [x] you have checked that the end-year of the copyright there is the current one;
* you have updated the AUTHORS file:
  - [x] you have added yourself to the AUTHORS file;
  - [x] if this is a new contribution, you have added it to the AUTHORS file;
* you have added everything to the user documentation:
  - [x] any new CMake configuration option;
  - [x] any change in the yaml config;
  - [x] any change to the public or plugin API;
  - [x] any other new or changed user-facing feature;
  - [x] any change to the dependencies;
* you have correctly linked your MR to one or more issues:
  - [x] your MR solves an identified issue;
  - [x] your commit contain the `Fix #issue` keyword to autoclose the issue when merged.
