### PR TITLE
update v1.8 to pass the workflow pages

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -54,9 +54,9 @@ jobs:
         docker run \
           --cidfile='docker.cid' \
           -v ${PWD}:/src:ro \
-          ghcr.io/pdidev/spack/latest/gcc/openmpi/all:v3 \
+          ghcr.io/pdidev/debian/unstable/openmpi/all:v3 \
           bash /src/run.sh
-        docker cp "$(cat docker.cid)":$(docker image inspect -f '{{.Config.WorkingDir}}' ghcr.io/pdidev/spack/latest/gcc/openmpi/all:v3)/docs/html public
+        docker cp "$(cat docker.cid)":$(docker image inspect -f '{{.Config.WorkingDir}}' ghcr.io/pdidev/debian/unstable/openmpi/all:v3)/docs/html public
     - name: Archive production artifacts
       uses: actions/upload-artifact@v4
       with:

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -33,6 +33,12 @@ on:
     branches: [ main, 'v[0-9]+\.[0-9]+' ]
     tags: '[0-9]+\.[0-9]+\.[0-9]+'
   pull_request:
+  workflow_dispatch:
+    inputs:
+      branch:
+        description: 'Define branch name'     
+        required: true
+        default: 'v1.8'
 jobs:
   pages:
     runs-on: ubuntu-24.04

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -35,7 +35,7 @@ on:
   pull_request:
 jobs:
   pages:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
     - name: Checkout branch
       uses: actions/checkout@v4

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,5 +1,5 @@
 #=============================================================================
-# Copyright (C) 2024 Commissariat a l'energie atomique et aux energies alternatives (CEA)
+# Copyright (C) 2025 Commissariat a l'energie atomique et aux energies alternatives (CEA)
 #
 # All rights reserved.
 #
@@ -34,11 +34,7 @@ on:
     tags: '[0-9]+\.[0-9]+\.[0-9]+'
   pull_request:
   workflow_dispatch:
-    inputs:
-      branch:
-        description: 'Define branch name'     
-        required: true
-        default: 'v1.8'
+
 jobs:
   pages:
     runs-on: ubuntu-24.04

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -40,7 +40,7 @@ jobs:
         compiler: ['gcc', 'clang']
         mpi:      ['openmpi', 'mpich']
         variant:  ['mini', 'all']
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
     - name: Checkout branch
       uses: actions/checkout@v4
@@ -56,7 +56,7 @@ jobs:
         base:    ['ubuntu/focal', 'ubuntu/rolling', 'debian/bookworm', 'debian/unstable']
         mpi:     ['openmpi', 'mpich']
         variant: ['mini', 'all']
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
     - name: Checkout branch
       uses: actions/checkout@v4

--- a/pdi/docs/Doxyfile
+++ b/pdi/docs/Doxyfile
@@ -31,6 +31,7 @@ DOXYFILE_ENCODING      = UTF-8
 PROJECT_NAME           = PDI
 PROJECT_NUMBER         = @PDI_VERSION@
 PROJECT_BRIEF          = 
+PROJECT_ICON           = ./_template/logo.png
 PROJECT_LOGO           = ./_template/logo.png
 OUTPUT_DIRECTORY       = @CMAKE_CURRENT_BINARY_DIR@
 CREATE_SUBDIRS         = NO

--- a/pdi/docs/_template/header.html
+++ b/pdi/docs/_template/header.html
@@ -7,16 +7,10 @@
 	<meta name="viewport" content="width=device-width, initial-scale=1"/>
 	<title>PDI: $title</title>
 	$mathjax
-	<!--BEGIN PROJECT_ICON-->
-	<link rel="icon" href="$relpath^$projecticon" type="image/x-icon" />
-	<!--END PROJECT_ICON-->
 	<link href="$relpath^tabs.css" rel="stylesheet" type="text/css"/>
 	<script type="text/javascript">var page_layout=1;</script>
 	<script type="text/javascript" src="$relpath^jquery.js"></script>
 	<script type="text/javascript" src="$relpath^dynsections.js"></script>
-	<!--BEGIN COPY_CLIPBOARD-->
-	<script type="text/javascript" src="$relpath^clipboard.js"></script>
-	<!--END COPY_CLIPBOARD-->
 	$treeview
 	$search
 	$darkmode


### PR DESCRIPTION
Fix a bug on the CI to obtain "pages.zip" for version 1.8. 
Add a button on 'github.com' to run the workflow "pages" (see "workflow_dispatch").

This zip file will be added in the release 1.8.3 as a new asset. 
This new asset is used to fix the issue https://github.com/pdidev/pdidev.github.io/issues/5.


# List of things to check before making a PR

Before merging your code, please check the following:

* [x] you have added a line describing your changes to the Changelog;
* [x] you have added unit tests for any new or improved feature;
* [x] In case you updated dependencies, you have checked pdi/docs/CheckList.md
* you have checked your code format:
  - [x] you have checked that you respect all conventions specified in CONTRIBUTING.md;
  - [x] you have checked that the indentation and formatting conforms to the `.clang-format`;
  - [x] you have documented with doxygen any new or changed function / class;
* you have correctly updated the copyright headers:
  - [x] your institution is in the copyright header of every file you (substantially) modified;
  - [x] you have checked that the end-year of the copyright there is the current one;
* you have updated the AUTHORS file:
  - [x] you have added yourself to the AUTHORS file;
  - [x] if this is a new contribution, you have added it to the AUTHORS file;
* you have added everything to the user documentation:
  - [x] any new CMake configuration option;
  - [x] any change in the yaml config;
  - [x] any change to the public or plugin API;
  - [x] any other new or changed user-facing feature;
  - [x] any change to the dependencies;
* you have correctly linked your MR to one or more issues:
  - [x] your MR solves an identified issue;
  - [x] your commit contain the `Fix #issue` keyword to autoclose the issue when merged.
