### PR TITLE
Fix an hdf5 test to be less strict (after libparaconf update)

### DIFF
--- a/plugins/decl_hdf5/tests/decl_hdf5_tests.cxx
+++ b/plugins/decl_hdf5/tests/decl_hdf5_tests.cxx
@@ -834,12 +834,6 @@ plugins:
 	PDI_expose("index", &index, PDI_OUT);
 
 	auto const array_data = make_a<std::array<int, 3>>();
-	EXPECT_CALL(
-		*this,
-		PdiError(
-			Eq(PDI_ERR_SPECTREE),
-			HasSubstr("Dataset selection is invalid for implicit dataset `group123/array_data'")
-		)
-	);
+	EXPECT_CALL(*this, PdiError(Eq(PDI_ERR_SPECTREE), HasSubstr("Dataset selection is invalid for implicit dataset `group123/array_data'")));
 	PDI_expose("array_data", array_data.data(), PDI_OUT);
 }

--- a/plugins/decl_hdf5/tests/decl_hdf5_tests.cxx
+++ b/plugins/decl_hdf5/tests/decl_hdf5_tests.cxx
@@ -838,9 +838,7 @@ plugins:
 		*this,
 		PdiError(
 			Eq(PDI_ERR_SPECTREE),
-			StrEq("Invalid entry in specification tree: (13:28 -> 13:49) Unable to share `array_data', "
-	              "Unable to share `array_data', while sharing `array_data', "
-	              "Dataset selection is invalid for implicit dataset `group123/array_data'")
+			HasSubstr("Dataset selection is invalid for implicit dataset `group123/array_data'")
 		)
 	);
 	PDI_expose("array_data", array_data.data(), PDI_OUT);


### PR DESCRIPTION
It seems to just be a version mismatch, we have an error on "all" here because a recent libparaconf (more recent than the vendored 1.0.3) gives a different error message than what we were checking against (hence an hdf5 error message is not exactly the same now).

# List of things to check before making a PR

Before merging your code, please check the following:

* [ ] you have added a line describing your changes to the Changelog;
* [ ] you have added unit tests for any new or improved feature;
* [ ] in case you updated dependencies, you have checked pdi/docs/CheckList.md;
* [ ] in case of a change in pdi.h, this same change must be reflected in mock_pdi/pdi.h;
* you have checked your code format:
  - [ ] you have checked that you respect all conventions specified in CONTRIBUTING.md;
  - [ ] you have checked that the indentation and formatting conforms to the `.clang-format`;
  - [ ] you have documented with doxygen any new or changed function / class;
* you have correctly updated the copyright headers:
  - [ ] your institution is in the copyright header of every file you (substantially) modified;
  - [ ] you have checked that the end-year of the copyright there is the current one;
* you have updated the AUTHORS file:
  - [ ] you have added yourself to the AUTHORS file;
  - [ ] if this is a new contribution, you have added it to the AUTHORS file;
* you have added everything to the user documentation:
  - [ ] any new CMake configuration option;
  - [ ] any change in the yaml config;
  - [ ] any change to the public or plugin API;
  - [ ] any other new or changed user-facing feature;
  - [ ] any change to the dependencies;
* you have correctly linked your MR to one or more issues:
  - [ ] your MR solves an identified issue;
  - [ ] your commit contain the `Fix #issue` keyword to autoclose the issue when merged.
