### PR TITLE
Add Doxygen path protection wrapper

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,6 +36,29 @@ project(PDI_DIST LANGUAGES C CXX)
 
 
 
+### Doxygen path protection wrapper
+
+find_program(SYSTEM_DOXYGEN_EXECUTABLE NAMES doxygen)
+
+if(SYSTEM_DOXYGEN_EXECUTABLE)
+	set(DOXYGEN_WRAPPER "${CMAKE_BINARY_DIR}/doxygen_wrapper.sh")
+
+	if(NOT EXISTS "${DOXYGEN_WRAPPER}")
+		file(WRITE "${DOXYGEN_WRAPPER}"
+			"#!/bin/sh\n"
+			"unset LD_LIBRARY_PATH\n"
+			"exec \"${SYSTEM_DOXYGEN_EXECUTABLE}\" \"$@\"\n"
+		)
+		execute_process(COMMAND chmod +x "${DOXYGEN_WRAPPER}")
+	endif()
+
+	set(DOXYGEN_EXECUTABLE "${DOXYGEN_WRAPPER}" CACHE FILEPATH "Path to doxygen wrapper" FORCE)
+else()
+	message(STATUS " Warning: Doxygen binary was not found on the system. Skipping wrapper creation.")
+endif()
+
+
+
 ### Build options
 
 ## Global options
@@ -324,6 +347,7 @@ if("${BUILD_DECL_HDF5_PLUGIN}" OR "${BUILD_DECL_NETCDF_PLUGIN}")
 			-DHDF5_BUILD_EXAMPLES:BOOL=OFF
 			-DHDF5_BUILD_TOOLS:BOOL=ON
 			-DHDF5_BUILD_UTILS:BOOL=OFF
+			-DHDF5_BUILD_DOC:BOOL=OFF
 			"-DHDF5_INSTALL_BIN_DIR:STRING=${CMAKE_INSTALL_BINDIR}"
 			"-DHDF5_INSTALL_CMAKE_DIR:STRING=${CMAKE_INSTALL_DATADIR}/cmake/hdf5"
 			"-DHDF5_INSTALL_DATA_DIR:STRING=${CMAKE_INSTALL_DATADIR}/hdf5"
@@ -388,6 +412,7 @@ if("${BUILD_DECL_NETCDF_PLUGIN}")
 			-DNETCDF_ENABLE_EXAMPLES:BOOL=OFF
 			-DNETCDF_ENABLE_FILTER_TESTING:BOOL=OFF
 			-DNETCDF_ENABLE_TESTS:BOOL=OFF
+			-DNETCDF_ENABLE_DOXYGEN:BOOL=OFF
 		VERSION 4.8
 	)
 	if("${NETCDF_FOUND}")

--- a/pdi/benchmarks/CMakeLists.txt
+++ b/pdi/benchmarks/CMakeLists.txt
@@ -39,6 +39,7 @@ if(NOT TARGET benchmark::benchmark)
   option(BENCHMARK_ENABLE_TESTING "Enable testing of the benchmark library." OFF)
   option(BENCHMARK_ENABLE_WERROR "Build Release candidates with -Werror." OFF)
   option(BENCHMARK_ENABLE_INSTALL "Enable installation of benchmark. (Projects embedding benchmark may want to turn this OFF.)" OFF)
+  set(BENCHMARK_ENABLE_DOXYGEN OFF CACHE BOOL "Disable benchmark doxygen documentation" FORCE)
   add_subdirectory("../../vendor/benchmark-4ed29ae/" "benchmark" EXCLUDE_FROM_ALL)
 endif()
 


### PR DESCRIPTION
Add Doxygen path protection wrapper (the vendored spdlog was used even if we chose the system's doxygen) and disable documentation for HDF5/NetCDF/GTest.

# List of things to check before making a PR

Before merging your code, please check the following:

* [ ] you have added a line describing your changes to the Changelog;
* [ ] you have added unit tests for any new or improved feature;
* [ ] in case you updated dependencies, you have checked pdi/docs/CheckList.md;
* [ ] in case of a change in pdi.h, this same change must be reflected in mock_pdi/pdi.h;
* you have checked your code format:
  - [ ] you have checked that you respect all conventions specified in CONTRIBUTING.md;
  - [ ] you have checked that the indentation and formatting conforms to the `.clang-format`;
  - [ ] you have documented with doxygen any new or changed function / class;
* you have correctly updated the copyright headers:
  - [ ] your institution is in the copyright header of every file you (substantially) modified;
  - [ ] you have checked that the end-year of the copyright there is the current one;
* you have updated the AUTHORS file:
  - [ ] you have added yourself to the AUTHORS file;
  - [ ] if this is a new contribution, you have added it to the AUTHORS file;
* you have added everything to the user documentation:
  - [ ] any new CMake configuration option;
  - [ ] any change in the yaml config;
  - [ ] any change to the public or plugin API;
  - [ ] any other new or changed user-facing feature;
  - [ ] any change to the dependencies;
* you have correctly linked your MR to one or more issues:
  - [ ] your MR solves an identified issue;
  - [ ] your commit contain the `Fix #issue` keyword to autoclose the issue when merged.
