### PR TITLE
Add AUTO strategy to find spdlog for ubuntu/rolling/mini

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -39,6 +39,7 @@ Jacques Morice - CEA (jacques.morice@cea.fr)
 * contribution to Decl'HDF5 features improvement, validation
 * fix issue [#55](https://github.com/pdidev/pkgs/issues/55)
 * fix issue [#582](https://github.com/pdidev/pkgs/issues/582)
+* fix issue [#30](https://github.com/pdidev/test_env/issues/582)
 
 Yacine Ould Rouis - CNRS (yacine.ould-rouis@inria.fr)
 * Fortran interface fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,9 @@ and this project adheres to
   fix [#690](https://github.com/pdidev/pdi/issues/690)
 * Updated the embedded version of zpp to fix an issue with Fortran on MacOSX,
   part of [#688](https://github.com/pdidev/pdi/issues/688)
+* Fix an issue build and tests script in case of spdlog mismatch between the
+  vendored version and dependency of doxygen,
+  [#712](https://github.com/pdidev/pdi/issues/712)
 
 #### Security
 

--- a/bin/build_and_run_all_tests
+++ b/bin/build_and_run_all_tests
@@ -108,6 +108,13 @@ then
 fi
 
 
+if [[ "x${PDI_SYSTEM}" =~ ^x(ubuntu|debian) ]] && dpkg-query -W 'libspdlog-dev' > /dev/null
+then
+	# Workaround: spdlog mismatch between the vendored version and dependency of doxygen
+	#             https://github.com/pdidev/test_env/issues/30
+	#             (see  https://github.com/pdidev/test_env/actions/runs/27519792247/job/81335351522)
+	CMAKE_FLAGS="${CMAKE_FLAGS} -DUSE_spdlog=SYSTEM"
+fi
 
 # And now for the actual tests
 


### PR DESCRIPTION
spdlog mismatch between the vendored version and dependency of doxygen for ubuntu rolling

(see https://github.com/pdidev/test_env/actions/runs/27519792247/job/81335351522)

# List of things to check before making a PR

Before merging your code, please check the following:

* [x] you have added a line describing your changes to the Changelog;
* [x] you have added unit tests for any new or improved feature;
* [x] in case you updated dependencies, you have checked pdi/docs/CheckList.md;
* [x] in case of a change in pdi.h, this same change must be reflected in mock_pdi/pdi.h;
* you have checked your code format:
  - [x] you have checked that you respect all conventions specified in CONTRIBUTING.md;
  - [x] you have checked that the indentation and formatting conforms to the `.clang-format`;
  - [x] you have documented with doxygen any new or changed function / class;
* you have correctly updated the copyright headers:
  - [x] your institution is in the copyright header of every file you (substantially) modified;
  - [x] you have checked that the end-year of the copyright there is the current one;
* you have updated the AUTHORS file:
  - [x] you have added yourself to the AUTHORS file;
  - [x] if this is a new contribution, you have added it to the AUTHORS file;
* you have added everything to the user documentation:
  - [x] any new CMake configuration option;
  - [x] any change in the yaml config;
  - [x] any change to the public or plugin API;
  - [x] any other new or changed user-facing feature;
  - [x] any change to the dependencies;
* you have correctly linked your MR to one or more issues:
  - [x] your MR solves an identified issue;
  - [x] your commit contain the `Fix #issue` keyword to autoclose the issue when merged.
