### PR TITLE
Add cmake option to override 'NetCDF_FIND_STRATEGIES'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,9 @@ and this project adheres to
 ### For users
 
 #### Added
+* Update the error messages for invalid SYSTEM dependencies of NetCDF and HDF5,
+  and document the cmake option to override 'NetCDF_FIND_STRATEGIES' as
+  requested in [#500](https://github.com/pdidev/pdi/issues/500)
 
 #### Changed
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -344,6 +344,13 @@ if("${BUILD_DECL_HDF5_PLUGIN}" OR "${BUILD_DECL_NETCDF_PLUGIN}")
 				"     * use another version of HDF5 from the system => pass `-DHDF5_ROOT=/path/to/hdf5/root/' to cmake"
 			)
 		endif()
+	elseif(NOT "EMBEDDED" STREQUAL "${USE_HDF5}")
+		message(FATAL_ERROR
+			"HDF5 setup failed: A suitable SYSTEM version (>= 1.10) could not be found.\n"
+			"    you have the following options:\n"
+			"     * build the EMBEDDED HDF5 from PDI distribution => pass `-DUSE_HDF5=EMBEDDED' to cmake\n"
+			"     * use another version of HDF5 from the system => pass `-DHDF5_ROOT=/path/to/hdf5/root/' to cmake"
+		)
 	endif()
 endif()
 
@@ -390,16 +397,27 @@ if("${BUILD_DECL_NETCDF_PLUGIN}")
 			-DNETCDF_ENABLE_TESTS:BOOL=OFF
 		VERSION 4.8
 	)
-	if("${NETCDF_FOUND}")
+	if("${NetCDF_FOUND}")
 		if("${BUILD_NETCDF_PARALLEL}" AND NOT "PARALLEL4" IN_LIST NetCDF_FEATURES)
 			message(FATAL_ERROR
 				"You requested a parallel NetCDF build (-DBUILD_NETCDF_PARALLEL=ON) but a sequential SYSTEM version has been found\n"
 				"    you have the following options:\n"
 				"     * build with this sequential NetCDF => pass `-DBUILD_NETCDF_PARALLEL=OFF' to cmake\n"
-				"     * build the EMBEDDED NetCDF from PDI distribution => pass `-DUSE_NETCDF=EMBEDDED' to cmake\n"
-				"     * use another version of NetCDF from the system => pass `-DNetCDF_CFGSCRIPT=/path/to/netcdf/bin/nc-config' to cmake"
+				"     * build the EMBEDDED NetCDF from PDI distribution => pass `-DUSE_NetCDF=EMBEDDED' to cmake\n"
+				"     * use another version of NetCDF from the system => pass `-DNetCDF_CFGSCRIPT=/path/to/netcdf/bin/nc-config' to cmake\n"
+				"       you may need to change the discovery order so the config script is tried first =>\n"
+				"       pass `-DNetCDF_FIND_STRATEGIES=\"CFGSCRIPT\"' to cmake"
 			)
 		endif()
+	elseif(NOT "EMBEDDED" STREQUAL "${USE_NetCDF}")
+		message(FATAL_ERROR
+			"NetCDF setup failed: A suitable SYSTEM version (>= 4.8) could not be found.\n"
+			"    you have the following options:\n"
+			"     * build the EMBEDDED NetCDF from PDI distribution => pass `-DUSE_NetCDF=EMBEDDED' to cmake\n"
+			"     * use another version of NetCDF from the system => pass `-DNetCDF_CFGSCRIPT=/path/to/netcdf/bin/nc-config' to cmake\n"
+			"       you may need to change the discovery order so the config script is tried first =>\n"
+			"       pass `-DNetCDF_FIND_STRATEGIES=\"CFGSCRIPT\"' to cmake"
+		)
 	endif()
 endif()
 

--- a/plugins/decl_netcdf/cmake/FindNetCDF.cmake
+++ b/plugins/decl_netcdf/cmake/FindNetCDF.cmake
@@ -62,6 +62,8 @@ includes:
 
 cmake_minimum_required(VERSION 3.22...4.2)
 
+set(NetCDF_FIND_STRATEGIES "CMAKE;CFGSCRIPT;PKGCONFIG;FALLBACK" CACHE STRING "Semicolon-separated list controlling NetCDF discovery order")
+
 set(_NetCDF_features_list CDF5 DAP DAP2 DAP4 DISKLESS HDF4 HDF5 JNA MMAP NC2 NC4 PARALLEL PARALLEL4 PNETCDF)
 
 macro(_NetCDF_remove_duplicates_from_beginning _list_name)


### PR DESCRIPTION
Add cmake option to override 'NetCDF_FIND_STRATEGIES', and multiple fixes and error message updates for HDF5 and NetCDF (when using SYSTEM dependencies)

Close #500, replace #697 

# List of things to check before making a PR

Before merging your code, please check the following:

* [x] you have added a line describing your changes to the Changelog;
* [ ] you have added unit tests for any new or improved feature;
* [ ] in case you updated dependencies, you have checked pdi/docs/CheckList.md;
* [ ] in case of a change in pdi.h, this same change must be reflected in mock_pdi/pdi.h;
* you have checked your code format:
  - [x] you have checked that you respect all conventions specified in CONTRIBUTING.md;
  - [x] you have checked that the indentation and formatting conforms to the `.clang-format`;
  - [ ] you have documented with doxygen any new or changed function / class;
* you have correctly updated the copyright headers:
  - [x] your institution is in the copyright header of every file you (substantially) modified;
  - [x] you have checked that the end-year of the copyright there is the current one;
* you have updated the AUTHORS file:
  - [ ] you have added yourself to the AUTHORS file;
  - [ ] if this is a new contribution, you have added it to the AUTHORS file;
* you have added everything to the user documentation:
  - [ ] any new CMake configuration option;
  - [ ] any change in the yaml config;
  - [ ] any change to the public or plugin API;
  - [ ] any other new or changed user-facing feature;
  - [ ] any change to the dependencies;
* you have correctly linked your MR to one or more issues:
  - [x] your MR solves an identified issue;
  - [ ] your commit contain the `Fix #issue` keyword to autoclose the issue when merged.
