### PR TITLE
Change for more strict version requirement of PDI

### DIFF
--- a/pdi/CMakeLists.txt
+++ b/pdi/CMakeLists.txt
@@ -368,7 +368,7 @@ install(FILES
 configure_file(cmake/PDIConfig.cmake.in PDIConfig.cmake @ONLY)
 write_basic_package_version_file("${PDI_BINARY_DIR}/PDIConfigVersion.cmake"
 		VERSION "${PDI_VERSION}"
-		COMPATIBILITY AnyNewerVersion
+		COMPATIBILITY SameMinorVersion
 )
 install(FILES
 		"${PDI_BINARY_DIR}/PDIConfig.cmake"


### PR DESCRIPTION
Close #692 
As we include breaking changes in minor versions of PDI, we can't use `AnyNewerVersion` anymore, and Damaris would be obliged to use a `find_package(PDI 1.11 REQUIRED)` specifying a strict minor version.
Template change on Damaris plugin side :
```
find_package(PDI 1.11 QUIET)
if(NOT PDI_FOUND)
	message(FATAL_ERROR
		"The Damaris plugin requires PDI 1.11.x (an incompatible or missing PDI was found).\n"
		"    This plugin depends on the SpecTree_error API introduced in PDI 1.11.\n"
		"    Install a matching PDI, or check out a plugin version compatible with your PDI."
	)
endif()
```

# List of things to check before making a PR

Before merging your code, please check the following:

* [ ] you have added a line describing your changes to the Changelog;
* [ ] you have added unit tests for any new or improved feature;
* [ ] in case you updated dependencies, you have checked pdi/docs/CheckList.md;
* [ ] in case of a change in pdi.h, this same change must be reflected in mock_pdi/pdi.h;
* you have checked your code format:
  - [ ] you have checked that you respect all conventions specified in CONTRIBUTING.md;
  - [ ] you have checked that the indentation and formatting conforms to the `.clang-format`;
  - [ ] you have documented with doxygen any new or changed function / class;
* you have correctly updated the copyright headers:
  - [ ] your institution is in the copyright header of every file you (substantially) modified;
  - [ ] you have checked that the end-year of the copyright there is the current one;
* you have updated the AUTHORS file:
  - [ ] you have added yourself to the AUTHORS file;
  - [ ] if this is a new contribution, you have added it to the AUTHORS file;
* you have added everything to the user documentation:
  - [ ] any new CMake configuration option;
  - [ ] any change in the yaml config;
  - [ ] any change to the public or plugin API;
  - [ ] any other new or changed user-facing feature;
  - [ ] any change to the dependencies;
* you have correctly linked your MR to one or more issues:
  - [ ] your MR solves an identified issue;
  - [ ] your commit contain the `Fix #issue` keyword to autoclose the issue when merged.
