### PR TITLE
Fix #737, with random_init of distribution_safe_integral

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,9 @@ and this project adheres to
   [#733](https://github.com/pdidev/pdi/issues/733)
 
 #### Fixed
+* Fix [#737](https://github.com/pdidev/pdi/issues/737) as random_init
+  from integral did not match IntType used (while bool and char remain
+  intentionally unsupported) 
 
 #### Security
 

--- a/pdi/include/pdi/testing.h
+++ b/pdi/include/pdi/testing.h
@@ -63,7 +63,9 @@
  */
 
 #include <algorithm>
+#include <concepts>
 #include <filesystem>
+#include <limits>
 #include <random>
 #include <ranges>
 #include <type_traits>
@@ -99,11 +101,18 @@ concept buildable_from = std::constructible_from<T, G&> && requires(G& g) {
 	};
 };
 
+/** Bridge the gap between integral and IntType, by disabling bool and char.
+ */
+template <class T>
+concept distribution_safe_integral
+	= std::same_as<T, short> || std::same_as<T, unsigned short> || std::same_as<T, int> || std::same_as<T, unsigned int> || std::same_as<T, long>
+   || std::same_as<T, unsigned long> || std::same_as<T, long long> || std::same_as<T, unsigned long long>;
+
 /** initialize an integral value with uniformly distributed values from the provided generator
  * \param gen the (pseudo)random generator
  * \param t the value to initialize
  */
-static inline void random_init(std::uniform_random_bit_generator auto& gen, std::integral auto& t)
+static inline void random_init(std::uniform_random_bit_generator auto& gen, distribution_safe_integral auto& t)
 {
 	using T = std::remove_reference_t<decltype(t)>;
 	t = std::uniform_int_distribution<T>(std::numeric_limits<T>::min())(gen);


### PR DESCRIPTION
From #735.
For exactly the integer types std::uniform_int_distribution permits, as its IntType parameter (short, int, long, long long, and unsigned variants). bool and char-like types are intentionally excluded as uniform_int_distribution is undefined behavior for those, and this file doesn't provide an alternative for them. A struct containing a bool or char member will fail to compile here rather than compile into a runtime undefined behavior.
To handle bool and char, the following would be needed :
```
// bool
static inline void random_init(std::uniform_random_bit_generator auto& gen, std::same_as<bool> auto& t)
{
	t = std::bernoulli_distribution(0.5)(gen);
}

// char
static inline void random_init(std::uniform_random_bit_generator auto& gen, narrow_integral auto& t)
{
	using T = std::remove_reference_t<decltype(t)>;
	using Wide = std::conditional_t<std::is_signed_v<T>, int, unsigned int>;
	t = static_cast<T>(std::uniform_int_distribution<Wide>(std::numeric_limits<T>::min(), std::numeric_limits<T>::max())(gen));
}
```

# List of things to check before making a PR

Before merging your code, please check the following:

* [x] you have added a line describing your changes to the Changelog;
* [ ] you have added unit tests for any new or improved feature;
* [x] in case you updated dependencies, you have checked pdi/docs/CheckList.md;
* [x] in case of a change in pdi.h, this same change must be reflected in mock_pdi/pdi.h;
* [x] in case of a new plugin, make sure the plugin issues the corresponding timer events;
* you have checked your code format:
  - [ ] you have checked that you respect all conventions specified in CONTRIBUTING.md;
  - [x] you have checked that the indentation and formatting conforms to the `.clang-format`;
  - [x] you have documented with doxygen any new or changed function / class;
* you have correctly updated the copyright headers:
  - [x] your institution is in the copyright header of every file you (substantially) modified;
  - [x] you have checked that the end-year of the copyright there is the current one;
* you have updated the AUTHORS file:
  - [x] you have added yourself to the AUTHORS file;
  - [x] if this is a new contribution, you have added it to the AUTHORS file;
* you have added everything to the user documentation:
  - [x] any new CMake configuration option;
  - [x] any change in the yaml config;
  - [x] any change to the public or plugin API;
  - [x] any other new or changed user-facing feature;
  - [x] any change to the dependencies;
* you have correctly linked your MR to one or more issues:
  - [x] your MR solves an identified issue;
  - [x] your commit contain the `Fix #issue` keyword to autoclose the issue when merged.
